### PR TITLE
Add custom style support to GraphiQL interface

### DIFF
--- a/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiQlWebFluxMvcAutoConfiguration.java
+++ b/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiQlWebFluxMvcAutoConfiguration.java
@@ -31,6 +31,7 @@ public class GraphiQlWebFluxMvcAutoConfiguration {
                     .modelAttribute("variables", properties.getVariables())
                     .modelAttribute("headers", properties.getHeaders())
                     .modelAttribute("plugins", properties.getPlugins())
+                    .modelAttribute("stylePath", properties.getStylePath())
                     .build();
             builder = builder.GET(properties.getPath(), graphiql);
         }

--- a/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiQlWebMvcAutoConfiguration.java
+++ b/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiQlWebMvcAutoConfiguration.java
@@ -29,6 +29,7 @@ public class GraphiQlWebMvcAutoConfiguration {
                     .modelAttribute("variables", properties.getVariables())
                     .modelAttribute("headers", properties.getHeaders())
                     .modelAttribute("plugins", properties.getPlugins())
+                    .modelAttribute("stylePath", properties.getStylePath())
                     .build();
             builder = builder.GET(properties.getPath(), graphiql);
         }

--- a/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiqlProperties.java
+++ b/graphql-graphiql-spring-boot-starter/src/main/java/ru/sadv1r/spring/graphql/editor/graphiql/configuration/GraphiqlProperties.java
@@ -36,6 +36,8 @@ public class GraphiqlProperties {
 
     private Cdn cdn = Cdn.UNPKG;
 
+    private String stylePath;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -98,6 +100,14 @@ public class GraphiqlProperties {
 
     public void setCdn(Cdn cdn) {
         this.cdn = cdn;
+    }
+
+    public String getStylePath() {
+        return stylePath;
+    }
+
+    public void setStylePath(String stylePath) {
+        this.stylePath = stylePath;
     }
 
     private static String readIfPath(String query) {

--- a/graphql-graphiql-spring-boot-starter/src/main/resources/templates/graphiql.html
+++ b/graphql-graphiql-spring-boot-starter/src/main/resources/templates/graphiql.html
@@ -25,6 +25,8 @@
             crossorigin th:src="|${cdnHost}/@graphiql/plugin-explorer/dist/index.umd.js|"></script>
     <link th:if="${plugins.contains(T(ru.sadv1r.spring.graphql.editor.graphiql.configuration.GraphiqlProperties.Plugin).EXPLORER)}"
           rel="stylesheet" th:href="|${cdnHost}/@graphiql/plugin-explorer/dist/style.css|"/>
+
+    <link th:if="${stylePath}" rel="stylesheet" th:href="|${stylePath}|"/>
 </head>
 <body>
 <div id="graphiql">Loading...</div>

--- a/samples/web-sample/src/main/resources/application.yaml
+++ b/samples/web-sample/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ spring:
       headers:
         x-test: test
       plugins: EXPLORER
+      stylePath: /style.css
     playground:
       settings:
         editor:

--- a/samples/web-sample/src/main/resources/static/style.css
+++ b/samples/web-sample/src/main/resources/static/style.css
@@ -1,0 +1,3 @@
+.graphiql-logo-link {
+    --color-neutral: 24, 28%, 32%;
+}

--- a/samples/webflux-sample/src/main/resources/application.yaml
+++ b/samples/webflux-sample/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ spring:
       headers:
         x-test: test
       plugins: EXPLORER
+      stylePath: /style.css
     playground:
       settings:
         editor:

--- a/samples/webflux-sample/src/main/resources/static/style.css
+++ b/samples/webflux-sample/src/main/resources/static/style.css
@@ -1,0 +1,3 @@
+.graphiql-logo-link {
+    --color-neutral: 24, 28%, 32%;
+}


### PR DESCRIPTION
The commit introduces a new property 'stylePath' to the GraphiQL configuration, allowing for custom style file paths to be specified