### PR TITLE
Updated OSSRH repository URLs to use the new staging API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,8 @@ configure(moduleProjects) {
 
         repositories {
             maven {
-                name = "OSSRH"
-                url = version.endsWith('SNAPSHOT') ? 'https://oss.sonatype.org/content/repositories/snapshots' : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                name = "ossrh-staging-api"
+                url = version.endsWith('SNAPSHOT') ? 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots' : 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
                 credentials {
                     username = System.env.OSSRH_USERNAME ?: project.findProperty('ossrhUsername') ?: ''
                     password = System.env.OSSRH_PASSWORD ?: project.findProperty('ossrhPassword') ?: ''


### PR DESCRIPTION
https://central.sonatype.org/pages/ossrh-eol/
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/